### PR TITLE
Add automated building & release of kerf1 for macOS (Linux broken)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - fcommon
     tags:
       - '*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,112 @@
+name: Build kerf1
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Build kerf
+        run: |
+          cd $GITHUB_WORKSPACE/src/
+          make all
+          mv kerf kerf-macos
+
+      - name: Test kerf
+        timeout-minutes: 1 # It is an interactive test, otherwise, a tool like expect should be used
+        continue-on-error: true
+        run: $GITHUB_WORKSPACE/src/kerf_test
+
+      - name: Upload build
+        uses: actions/upload-artifact@v3 # All users can find the artifacts inside of the actions
+        with:
+          name: kerf-macOS
+          path: ${{ github.workspace }}/src/kerf-macos
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download libedit (3.1 thrysoee.dk macports) w/ checksum
+        run: |
+          wget https://thrysoee.dk/editline/libedit-20210910-3.1.tar.gz
+          echo "b7361c277f971ebe87e0e539e5e1fb01a4ca1bbab61e199eb97774d8b60dddeb9e35796faf9cc68eb86d1890e8aac11db13b44b57ccc8302d559741fbe9d979e  libedit-20210910-3.1.tar.gz" | sha512sum -c
+
+      - name: Install libedit
+        run: |
+          tar -xf libedit-20210910-3.1.tar.gz
+          cd libedit-20210910-3.1
+          ./configure
+          make
+          sudo make install
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Build kerf
+        run: |
+          cd $GITHUB_WORKSPACE/src/
+          make all
+          mv kerf kerf-linux
+
+      - name: Test kerf
+        timeout-minutes: 1 # It is an interactive test, otherwise, a tool like expect should be used
+        continue-on-error: true
+        run: $GITHUB_WORKSPACE/src/kerf_test
+
+      - name: Upload build
+        uses: actions/upload-artifact@v3 # All users can find the artifacts inside of the actions
+        with:
+          name: kerf-linux
+          path: ${{ github.workspace }}/src/kerf-linux
+
+  release:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [build-macos, build-linux]
+    steps:
+      - name: Download macOS artifact
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+          name: kerf-macOS
+          path: output
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+          name: kerf-linux
+          path: output
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v3
+        continue-on-error: true
+        with:
+          name: kerf-windows
+          path: output
+
+      - name: Make binaries executable
+        continue-on-error: true
+        run: |
+          chmod +x output/kerf-macos;
+          chmod +x output/kerf-linux;
+          chmod +x output/kerf-windows.exe
+
+      - name: Draft Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/') # Only DRAFT releases on tags, owner still has to write body and publish it
+        with:
+          draft: true
+          tag_name: ${{ steps.vars.outputs.tag_name }}
+          files: |
+            output/kerf-macos
+            output/kerf-linux
+            output/kerf-windows.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,18 +35,8 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - name: Download libedit (3.1 thrysoee.dk macports) w/ checksum
-        run: |
-          wget https://thrysoee.dk/editline/libedit-20210910-3.1.tar.gz
-          echo "b7361c277f971ebe87e0e539e5e1fb01a4ca1bbab61e199eb97774d8b60dddeb9e35796faf9cc68eb86d1890e8aac11db13b44b57ccc8302d559741fbe9d979e  libedit-20210910-3.1.tar.gz" | sha512sum -c
-
       - name: Install libedit
-        run: |
-          tar -xf libedit-20210910-3.1.tar.gz
-          cd libedit-20210910-3.1
-          ./configure
-          make
-          sudo make install
+        run: sudo apt-get install -y libedit-dev
 
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/src/Makefile
+++ b/src/Makefile
@@ -40,6 +40,7 @@ ifeq (linux,$(OS))
 # LDFLAGS +=  -ldl -lm -lpthread -lrt -ltermcap -lz ./libedit.a
 LDFLAGS +=  -ldl -lm -lpthread -lrt -ltermcap -lz -ledit
 CFLAGS  += -rdynamic -m64 # -w
+CFLAGS += -fcommon
 ifneq (,$(findstring DDEBUG, $(CFLAGS)))
   $(info Adding -g debug flag)
   CFLAGS  += -fPIC # -fPIE -pie 

--- a/src/kerf.h
+++ b/src/kerf.h
@@ -194,6 +194,7 @@ static char *kerf =
 
 #ifdef __linux
 #include <sys/eventfd.h>
+#include <sys/sysmacros.h>
 #endif
 
 #if defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__NetBSD__)

--- a/src/main.c
+++ b/src/main.c
@@ -443,7 +443,7 @@ void cleanup()
   }
   else
   {
-    fprintf(stderr,"[DEBUG]\x1B[1;37;41mFAILED: Debug failure.\x1B[0m\n");
+    fprintf(stderr,"[DEBUG] \x1B[1;37;41mFAILED: Debug failure.\x1B[0m\n");
   }
 
 #endif


### PR DESCRIPTION
This PR adds complete support for automated building and (on tags) release of kerf1 for macOS. (and partial Linux)

## macOS works - Linux errors out
kerf1 seems to be built with macOS in mind: it uses clang, and builds flawlessly under macOS (clang+GNU ld).

To build under Linux, a couple of changes have to be done:
- an include to `sys/macros.h` is missing for `wire.c` for Linux
- `libedit` seems to be macOS specific (see [`Makefile` comment l.39](https://github.com/kevinlawler/kerf1/blob/master/src/Makefile#L39)). As such, the [macports version](https://ports.macports.org/port/libedit/) was taken and built manually inside of the workflow.

This doesn't seem to suffice though, as it still errors out.
If both of these steps are taken inside of a [GitHub-provided Codespaces VM](https://github.com/features/codespaces), the build succeeds, but the final binary errors out at run-time, complaining about the libedit library file.

I have tested around and modified the source code with a friend, and these things might hinder the build:
1. possibly the library not being found (giving the exact path `/usr/local/lib/libedit.a` seems to help a bit in the Makefile instead of `-ledit`) This seems to be somewhat confirmed through [the comment (l.39) about "self use"](https://github.com/kevinlawler/kerf1/blob/master/src/Makefile#L39), but no .a file is to be found. @kevinlawler plz fix the broken linux build, it's not clear where that .a file comes from or how it should be built from source
2. including kerf.h instead of lz4.h inside of lz4.c tself. If that is fixed, it needs adding some includes and typedefs at the [`extern "C"`, `Vesion` part](https://github.com/kevinlawler/kerf1/blob/master/src/lz4.h#L49) (inside if lz4.h)
3. a [compiler option inside of lz4.c](https://github.com/kevinlawler/kerf1/blob/master/src/lz4.c#L82) that's commented, about stdc version

The usage of termcap doesn't help either: on Arch Linux for example, it finds itself [in the AUR](https://aur.archlinux.org/packages/termcap) because the maintainers don't seem to consider it useful/up to todays standards anymore.

Linux is being left in, as only small changes have to be made for it to work. For example, if the Makefile is modified on the tree and the library added there, only a removal of the manual building of the library is needed.

----
## Workflow - Automatic building and releases
To sum up the workflow:
- all push to master:
   - builds and tests kerf1
   - uploads download binaries/artifacts (30 day expiration max and by default i think)
- all tags:
   - builds and tests kerf1
   - uploads download binaries/artifacts (30 day expiration max and by default i think)
   - creates a **draft release**, EVEN IF the builds fail

As such, even if the linux build is broken, a draft release is created.
This also means that releases have to be tagged, and that the owner of the repo still has to fill in the body of the release and publish it, but the executables are already present. This is to avoid un-wanted tags to be published.

## Tldr
- macOS works, building seems to be broken for Linux, probably specific libedit library needed by @kevinlawler 
- Draft releases are created, the owner just needs to publish them (to avoid mis-publish)

See the (published) release by yourself: https://github.com/luxemboye/kerf1/releases/tag/v0.0.1
Made by this run: https://github.com/luxemboye/kerf1/actions/runs/2724745156