### PR TITLE
Statically linked Linux binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - fcommon
+      - alpine-build
     tags:
       - '*'
 
@@ -56,16 +56,17 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - name: Install libedit
-        run: sudo apt-get install -y libedit-dev
-
       - name: Checkout repo
         uses: actions/checkout@v3
+
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Build kerf
         run: |
           cd $GITHUB_WORKSPACE/src/
-          make all
+          docker build -o . .
+          tar xvf kerf1.tar
           mv kerf kerf-linux
 
       - name: Install expect to test kerf
@@ -73,7 +74,7 @@ jobs:
 
       - name: Test kerf
         run: |
-          cd $GITHUB_WORKSPACE/src/
+          cd $GITHUB_WORKSPACE/src
           expect <<EOD
               set timeout 60
               spawn ./kerf_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build kerf
         run: |
           cd $GITHUB_WORKSPACE/src/
-          DOCKER_BUILDKIT=1 docker build -o . .
+          docker buildx build --output . .
           tar xvf kerf1.tar
           mv kerf kerf-linux
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build kerf
         run: |
           cd $GITHUB_WORKSPACE/src/
-          docker build -o . .
+          DOCKER_BUILDKIT=1 docker build -o . .
           tar xvf kerf1.tar
           mv kerf kerf-linux
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - alpine-build
     tags:
       - '*'
 

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,18 +1,14 @@
 FROM alpine:3.16 AS build
 RUN apk update && apk add clang musl-dev compiler-rt lld binutils make ncurses-dev fts-dev zlib-dev zlib-static libedit-dev libedit-static
-RUN cd /tmp/
 RUN wget http://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz
 RUN echo "91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100  termcap-1.3.1.tar.gz" | sha256sum -c
-RUN tar xf termcap-1.3.1.tar.gz && cd termcap-1.3.1
+RUN tar xf termcap-1.3.1.tar.gz
 RUN ln -s /usr/bin/clang /usr/bin/cc
-RUN ./configure && make && make install
-RUN mkdir /tmp/kerf1 && cd /tmp/kerf1/
-ADD ./* /tmp/kerf1/
-RUN cd src
-RUN STATIC=1 make all
+RUN cd termcap-1.3.1 && ./configure && make && make install
+RUN mkdir /kerf1/
+ADD ./* /kerf1/
+RUN cd /kerf1/ && STATIC=1 make all
+RUN tar cvf kerf1.tar -C /kerf1/ kerf kerf_test
 
-FROM scratch AS export-release
-COPY --from=build /tmp/kerf1/src/kerf /
-
-FROM scratch AS export-test
-COPY --from=build /tmp/kerf1/src/kerf_test /
+FROM scratch AS export
+COPY --from=build /kerf1.tar /

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.16 AS build
+RUN apk update && apk add clang musl-dev compiler-rt lld binutils make ncurses-dev fts-dev zlib-dev zlib-static libedit-dev libedit-static
+RUN cd /tmp/
+RUN wget http://ftp.gnu.org/gnu/termcap/termcap-1.3.1.tar.gz
+RUN echo "91a0e22e5387ca4467b5bcb18edf1c51b930262fd466d5fda396dd9d26719100  termcap-1.3.1.tar.gz" | sha256sum -c
+RUN tar xf termcap-1.3.1.tar.gz && cd termcap-1.3.1
+RUN ln -s /usr/bin/clang /usr/bin/cc
+RUN ./configure && make && make install
+RUN mkdir /tmp/kerf1 && cd /tmp/kerf1/
+ADD ./* /tmp/kerf1/
+RUN cd src
+RUN STATIC=1 make all
+
+FROM scratch AS export-release
+COPY --from=build /tmp/kerf1/src/kerf /
+
+FROM scratch AS export-test
+COPY --from=build /tmp/kerf1/src/kerf_test /

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,11 @@ ifneq (,$(findstring DDEBUG, $(CFLAGS)))
   CFLAGS += -g
 endif
 
+ifdef STATIC
+  CFLAGS += -static
+  LDFLAGS += -lfts
+endif
+
 $(shell mkdir -p "$(OBJDIR)")
 
 GLOBAL_HEADERS = kerf.h dry.h help.h

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ ifneq (,$(findstring DDEBUG, $(CFLAGS)))
 endif
 
 ifdef STATIC
-  CFLAGS += -static
+  CFLAGS += -static --rtlib=compiler-rt
   LDFLAGS += -lfts
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,8 @@ ifneq (,$(findstring DDEBUG, $(CFLAGS)))
 endif
 
 ifdef STATIC
-  CFLAGS += -static --rtlib=compiler-rt
-  LDFLAGS += -lfts
+  CFLAGS += -static --rtlib=compiler-rt -fuse-ld=lld
+  LDFLAGS += -lfts -L/usr/local/lib
 endif
 
 $(shell mkdir -p "$(OBJDIR)")

--- a/src/kerf.h
+++ b/src/kerf.h
@@ -186,6 +186,7 @@ static char *kerf =
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <sys/file.h>
 #include <sysexits.h>
 #include <termios.h>
 #include <time.h>

--- a/src/stamp.c
+++ b/src/stamp.c
@@ -543,7 +543,7 @@ I stampI_from_TM_NANOS(TM_NANOS x, bool local)
   
   if(use_local)
   {
-    unixtime = timelocal(&t);
+    unixtime = mktime(&t);
   }
   else
   {
@@ -895,7 +895,7 @@ K parse_absolute_date(K x, bool local)
   
   if(local)
   {
-    unixtime = timelocal(&t);
+    unixtime = mktime(&t);
   }
   else
   {
@@ -924,7 +924,7 @@ K parse_absolute_time(K x, bool local)
   
   if(local)
   {
-    unixtime = timelocal(&t);
+    unixtime = mktime(&t);
   }
   else
   {


### PR DESCRIPTION
This PR makes the final uploaded binary of kerf **statically linked**. This means, there are **no missing library** issues for the user.
Previously, the user might have had to install libedit on Ubuntu, and other distributions would probably have been flaky.

Now, the binary is built in an [**Alpine Linux** container](https://hub.docker.com/_/alpine/) using purely LLVM tools (`clang` + `lld` + `compiler-rt`) and `musl`.
To achieve this, some changes had to be made to the code base to make it more portable.
Sadly, as `termcap` is getting very out of date, it is getting increasingly hard to properly support that part.
For context, `termcap` is missing in many distributions: [ArchLinux only has it in the AUR](https://aur.archlinux.org/packages/termcap), Alpine Linux is missing it entirely. On top of that, the [latest version found on the GNU ftp](https://ftp.gnu.org/gnu/termcap/) is from *March **2002***.

The last commit on this branch at the time of writing (`c06a2f6`) has built successfully: https://github.com/luxemboye/kerf1/actions/runs/2908213473
I have tested (ran) the binary successfully inside of a Debian, Ubuntu, Arch and Alpine container.

---
While this solution isn't perfect, it is much simpler than maintaining a suite of package scripts for all the major distributions. It still allows users to have a single binary of `kerf1` that runs anywhere, but simply lacks the seamless experience of a natively supported package.