### PR TITLE
Automatically publish "continuous" releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,11 +134,22 @@ jobs:
           chmod +x output/kerf-windows.exe
 
       - name: Draft Release
+        continue-on-error: true
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/') # Only DRAFT releases on tags, owner still has to write body and publish it
         with:
           draft: true
           tag_name: ${{ steps.vars.outputs.tag_name }}
+          files: |
+            output/kerf-macos
+            output/kerf-linux
+
+      - name: Auto publish continuous pre-release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "continuous"
+          prerelease: true
           files: |
             output/kerf-macos
             output/kerf-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,19 +119,11 @@ jobs:
           name: kerf-linux
           path: output
 
-      - name: Download Windows artifact
-        uses: actions/download-artifact@v3
-        continue-on-error: true
-        with:
-          name: kerf-windows
-          path: output
-
       - name: Make binaries executable
         continue-on-error: true
         run: |
           chmod +x output/kerf-macos;
           chmod +x output/kerf-linux;
-          chmod +x output/kerf-windows.exe
 
       - name: Draft Release
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,4 +142,3 @@ jobs:
           files: |
             output/kerf-macos
             output/kerf-linux
-            output/kerf-windows.exe


### PR DESCRIPTION
After [some](https://github.com/AppImageCrafters/appimage-builder) [browsing](https://github.com/AppImageCrafters/appimage-builder/releases) [around](https://github.com/AppImageCrafters/appimage-builder/blob/main/.github/workflows/continuous-builds.yml), I ended up finding a [GitHub action that facilitates publishing of "latest" releases](https://github.com/marketplace/actions/automatic-releases).

This allows `master` branch binaries to be published under "Releases", while not technically publishing a version, thus **facilitating the download of binaries**.
For context, the current system necessitates people to browse through GitHub Action runs to download a ZIP, unarchive it and `chmod +x` it, on top of that, those GitHub Actions artifacts are only available for 30 or so days.
In comparaison, (pre-)releases are much easier to find and provide a non-expiring direct download link to binaries.

An example is visible here:
- https://github.com/luxemboye/kerf1/releases
- https://github.com/luxemboye/kerf1/releases/tag/continuous

---
EDIT: Merging #19 first might be a better idea due to the simplicity of this second PR.