### PR TITLE
Fix typo in refmanual.tex

### DIFF
--- a/manual/refmanual.tex
+++ b/manual/refmanual.tex
@@ -2590,7 +2590,7 @@ The function \primu{send\_async}{sendAsync}\texttt{(handle, x)} will send a stri
 
 \vspace{0.5cm}
 
-The function \primu{send\_sync}{sendSync}\texttt{(handle, x)} will send a string \texttt{y} to a remote Kerf instance, waiting for a reply. \\\texttt{y} will be \prim{eval}ed on the remote server, and the result will be returned.
+The function \primu{send\_sync}{sendSync}\texttt{(handle, y)} will send a string \texttt{y} to a remote Kerf instance, waiting for a reply. \\\texttt{y} will be \prim{eval}ed on the remote server, and the result will be returned.
 
 \begin{Verbatim}
 KeRF> \typed{c: open_socket("localhost", "1234")}


### PR DESCRIPTION
I went to fix the docs for `mapleft` and `mapright` in the reference manual because the operator forms are backwards right now (i.e., the PDF says that `mapleft` is synonymous with `\>` and `mapright` is synonymous with `\<`), and I was going to fix this really minor typo as well since I already had the editor up.

Turns out the `\<` vs. `\>` mixup has already been fixed in the TeX source, but I figured I'd open this PR anyway with the `send_sync` fix and then if this is ever merged, you could update the generated PDF to capture both fixes.